### PR TITLE
HHVM is no longer supported on Ubuntu Precise.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: php
 php:
   - 5.5
   - 5.4
-  - hhvm
 script: phpunit Test.php


### PR DESCRIPTION
HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.